### PR TITLE
feat(phase-ii): PBKDF2 primitive + unified passphrase-KDF + MasterKey brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `NONCE_LENGTH` export remains as a `@deprecated` alias for `XCHACHA_NONCE_LENGTH` to keep any external callers compiling; removal scheduled for v0.3.
 - `Algorithm` type documents the 96-bit-vs-192-bit nonce trade-off, the per-key message bound for AES-GCM (2³² per NIST SP 800-38D §8.3, hard cap enforced in Phase IV per design-review blocker B2), and the commitment's key-committing (not context-committing) property.
 
+### Added — Phase II (plan-02, PBKDF2 + passphrase-KDF unification)
+
+- **`MasterKey` branded type** (`ISecureBuffer & { readonly __brand: 'MasterKey' }`) — the 32-byte key that seeds `EnvelopeClient` (Phase IV) and `@de-otio/keyring`'s tier system. The brand prevents key-confusion at compile time (design-review blocker B8): passphrase-derived bytes cannot be handed to an AEAD primitive as a CEK without an explicit unbranding cast.
+- **`deriveMasterKeyFromPassphrase(passphrase, salt, params, options?)`** in `src/passphrase.ts` — unified, async, branded-return passphrase KDF with `AbortSignal` support. Discriminated-union `PassphraseKdfParams`:
+  - `{ algorithm: 'argon2id' }` — **mandatory default** at OWASP 2023 second-tier parameters (t=3, m=64 MiB, p=1, dkLen=32).
+  - `{ algorithm: 'pbkdf2-sha256', iterations: N }` — **compatibility-only fallback**. WebCrypto-constrained runtimes where shipping WASM Argon2 is not viable. Runtime one-time `console.warn` when this branch is taken, naming the Argon2id-preferred posture.
+- **PBKDF2-SHA256 iteration floor: 1,000,000** (raised from OWASP 2023's 600,000 per design-review should-fix S1 — hardware improves ~30%/year; the 1M floor keeps PBKDF2-on-2026-hardware roughly at OWASP's intended cost budget). Reviewed annually per SECURITY.md cadence commitments.
+- **`pbkdf2Sha256(passphrase, salt, params)`** primitive export under `./primitives` — thin wrapper over `@noble/hashes/pbkdf2`, pure-JS, runs on every WebCrypto-compliant runtime.
+- **`asMasterKey(buf: ISecureBuffer): MasterKey`** — brand-assertion helper for advanced callers (test vectors, migration paths, hardware-sourced key material). Rejects buffers not exactly 32 bytes.
+- RFC 7914 §11 PBKDF2-SHA256 Known-Answer Tests covering `c=1` (fast path) and `c=80000` (full iteration). Matches the most-reproduced PBKDF2-SHA256 reference vectors; a regression in `@noble/hashes/pbkdf2` or in the wrapper's iteration/length handling will fail these.
+- `AbortSignal` on `deriveMasterKeyFromPassphrase`: checked pre- and post-derivation. Argon2id runs synchronously inside `@noble/hashes` so the signal does not interrupt mid-iteration; a future release may chunk the loop.
+- Internal testing helper `_resetPbkdf2WarnForTests()` exported (underscore-prefixed) so the one-time-per-process warn flag can be reset in tests. Not part of the public API.
+
+### Notes — Phase II
+
+- **Argon2id migration (design-review B3 / plan §5 / §3.2) is a no-op.** chaoskb's `sodium-native`-backed Argon2 was extracted to `@noble/hashes/argon2` back in Phase B of plan-01 (see v0.1.0-alpha.1 entry below), so Phase II has no algorithm-implementation change on the Argon2 side — only the unified caller surface is new.
+- Runtime deps unchanged: `@noble/hashes` was already at the required version; `sodium-native` stays for `SecureBuffer`'s mlock/zero (Node-only, unchanged).
+
 
 ## [0.1.0-alpha.1] - 2026-04-18
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,18 @@ export {
   downgradeToV1,
   type EncryptV1Args,
 } from './envelope/index.js';
+export {
+  asMasterKey,
+  deriveMasterKeyFromPassphrase,
+  PBKDF2_SHA256_MIN_ITERATIONS,
+  type DeriveMasterKeyOptions,
+  type PassphraseKdfParams,
+} from './passphrase.js';
 export type {
   Algorithm,
   AnyEnvelope,
   EnvelopeV1,
   EnvelopeV2,
   ISecureBuffer,
+  MasterKey,
 } from './types.js';

--- a/src/passphrase.ts
+++ b/src/passphrase.ts
@@ -1,0 +1,145 @@
+import { deriveFromPassphrase as argon2DeriveFromPassphrase } from './primitives/argon2.js';
+import { pbkdf2Sha256 } from './primitives/pbkdf2.js';
+import { SecureBuffer } from './secure-buffer.js';
+import type { ISecureBuffer, MasterKey } from './types.js';
+
+/**
+ * Unified passphrase-KDF API.
+ *
+ * Produces a branded {@link MasterKey} (32 bytes) that feeds the HKDF
+ * subkey derivation inside `EnvelopeClient`. Callers must not use the
+ * output directly as a content-encryption key — the brand enforces this
+ * at the type level (design-review B8).
+ *
+ * ## Algorithm selection
+ *
+ * Argon2id is the **mandatory default** for new consumers. Its
+ * memory-hard design defeats GPU/ASIC password-cracking attacks that
+ * PBKDF2 does not. Parameters follow OWASP 2023 second-tier
+ * recommendations (`t=3, m=64 MiB, p=1, dkLen=32`) and are fixed — callers
+ * who want different parameters compose Argon2id themselves against
+ * {@link argon2DeriveFromPassphrase}.
+ *
+ * PBKDF2-SHA256 exists for **compatibility only**: WebCrypto-constrained
+ * runtimes where shipping WASM Argon2 is not viable (some browser
+ * extension policies, some corporate-locked browsers). Taking the
+ * PBKDF2 branch emits a one-time `console.warn` per process, naming the
+ * Argon2id-preferred posture.
+ *
+ * The PBKDF2 iteration floor is enforced at **1,000,000** for SHA-256.
+ * OWASP 2023's "600,000" minimum is the published floor but hardware
+ * improves ~30%/year; the 1M floor (design-review S1) keeps
+ * PBKDF2-on-2026-hardware at roughly OWASP's 2023 intent. Reviewed
+ * annually (SECURITY.md cadence commitments).
+ *
+ * ## Cancellation
+ *
+ * `deriveMasterKeyFromPassphrase` is `async` and accepts an optional
+ * `AbortSignal`. Argon2id runs synchronously inside `@noble/hashes` —
+ * the signal is checked before and after derivation, which covers the
+ * tab-navigation and request-timeout cases but not mid-iteration abort.
+ * A future release may chunk the Argon2id loop; the public shape stays
+ * the same.
+ *
+ * ## Passphrase handling
+ *
+ * The UTF-8 bytes of `passphrase` are zeroed after derivation regardless
+ * of which branch ran. The original JS string lives in the V8 heap until
+ * GC and **cannot be zeroed by this library** — callers handling
+ * highly-sensitive passphrases should minimise the time the string exists
+ * (e.g. take it from a controlled input, pass directly, do not log).
+ */
+
+export type PassphraseKdfParams =
+  | { algorithm: 'argon2id' }
+  | { algorithm: 'pbkdf2-sha256'; iterations: number };
+
+/** Minimum PBKDF2-SHA256 iterations accepted by this library. Raised from
+ *  OWASP 2023's 600,000 to keep PBKDF2-on-2026-hardware roughly at the
+ *  intended cost budget (design-review S1). */
+export const PBKDF2_SHA256_MIN_ITERATIONS = 1_000_000;
+
+let pbkdf2WarnEmitted = false;
+
+export interface DeriveMasterKeyOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Derive a 32-byte {@link MasterKey} from a passphrase. Brand the output
+ * so it cannot be mis-used as an AEAD key (design-review B8).
+ *
+ * @throws `AbortError` if `signal` fires.
+ * @throws `Error` if PBKDF2 iteration count is below the floor.
+ */
+export async function deriveMasterKeyFromPassphrase(
+  passphrase: string,
+  salt: Uint8Array,
+  params: PassphraseKdfParams,
+  options?: DeriveMasterKeyOptions,
+): Promise<MasterKey> {
+  options?.signal?.throwIfAborted();
+
+  if (params.algorithm === 'argon2id') {
+    const buf = argon2DeriveFromPassphrase(passphrase, salt);
+    options?.signal?.throwIfAborted();
+    return asMasterKey(buf);
+  }
+
+  if (params.algorithm === 'pbkdf2-sha256') {
+    if (!Number.isInteger(params.iterations) || params.iterations < PBKDF2_SHA256_MIN_ITERATIONS) {
+      throw new Error(
+        `PBKDF2-SHA256 iterations must be an integer >= ${PBKDF2_SHA256_MIN_ITERATIONS}, got ${params.iterations}`,
+      );
+    }
+    warnOncePbkdf2();
+
+    const passphraseBytes = Buffer.from(passphrase, 'utf8');
+    let derived: Uint8Array | undefined;
+    try {
+      derived = pbkdf2Sha256(passphraseBytes, salt, { iterations: params.iterations });
+      options?.signal?.throwIfAborted();
+      return asMasterKey(SecureBuffer.from(Buffer.from(derived)));
+    } finally {
+      if (derived) derived.fill(0);
+      passphraseBytes.fill(0);
+    }
+  }
+
+  const _exhaustive: never = params;
+  throw new Error(`unknown KDF algorithm: ${JSON.stringify(_exhaustive)}`);
+}
+
+/**
+ * Brand an existing {@link ISecureBuffer} as a {@link MasterKey}. Intended
+ * for advanced callers (test vectors, migration paths, raw key material
+ * from a hardware source). Routine use should go through
+ * {@link deriveMasterKeyFromPassphrase}.
+ *
+ * The buffer must be exactly 32 bytes; other widths throw.
+ */
+export function asMasterKey(buf: ISecureBuffer): MasterKey {
+  if (buf.length !== 32) {
+    throw new Error(`MasterKey must be 32 bytes, got ${buf.length}`);
+  }
+  return buf as MasterKey;
+}
+
+function warnOncePbkdf2(): void {
+  if (pbkdf2WarnEmitted) return;
+  pbkdf2WarnEmitted = true;
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[@de-otio/crypto-envelope] PBKDF2-SHA256 used — prefer Argon2id where available. ' +
+      'See SECURITY.md for guidance.',
+  );
+}
+
+/**
+ * Internal: reset the once-per-process PBKDF2 compatibility-warning flag.
+ * Not part of the public API; underscore-prefixed to mark it as a testing
+ * affordance. Removing it would break no documented consumer.
+ */
+export function _resetPbkdf2WarnForTests(): void {
+  pbkdf2WarnEmitted = false;
+}

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -21,5 +21,6 @@ export {
 export { deriveKey, deriveContentKey, deriveCommitKey } from './hkdf.js';
 export { computeCommitment, verifyCommitment } from './commitment.js';
 export { deriveFromPassphrase } from './argon2.js';
+export { pbkdf2Sha256, PBKDF2_DEFAULT_OUTPUT_LENGTH, type Pbkdf2Params } from './pbkdf2.js';
 
 export type { ISecureBuffer } from '../types.js';

--- a/src/primitives/pbkdf2.ts
+++ b/src/primitives/pbkdf2.ts
@@ -1,0 +1,45 @@
+import { pbkdf2 } from '@noble/hashes/pbkdf2.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+/**
+ * PBKDF2-SHA256 primitive — a WebCrypto-compatible fallback for runtimes
+ * where Argon2id is not available (restricted browser extensions, some
+ * FIPS-constrained environments). Argon2id is the preferred algorithm
+ * everywhere it can run; PBKDF2 is the compatibility-only path. See
+ * `src/passphrase.ts` for the unified caller surface.
+ *
+ * Parameters are caller-supplied rather than baked in, but callers are
+ * expected to enforce the iteration floor at the passphrase-module layer
+ * (`src/passphrase.ts` rejects anything below 1_000_000 for SHA-256).
+ *
+ * Output length is fixed at 32 bytes because the downstream consumer is
+ * always `EnvelopeClient`, which HKDFs a 32-byte master into CEK +
+ * commitKey. Broader output widths would be a different primitive.
+ */
+export const PBKDF2_DEFAULT_OUTPUT_LENGTH = 32;
+
+export interface Pbkdf2Params {
+  /** Number of PBKDF2 iterations. Passphrase-layer enforces floor. */
+  iterations: number;
+  /** Derived key length in bytes. Defaults to 32. */
+  dkLen?: number;
+}
+
+/**
+ * Pure-JS PBKDF2-SHA256 via `@noble/hashes`. Synchronous on every runtime
+ * where `@noble/hashes` runs (Node, browsers, Deno, Bun, Cloudflare
+ * Workers). Not yieldable mid-computation — the `AbortSignal`-capable
+ * wrapper in `src/passphrase.ts` checks before starting and after
+ * returning, which is the best we can do without re-implementing PBKDF2
+ * in chunks.
+ */
+export function pbkdf2Sha256(
+  passphrase: Uint8Array,
+  salt: Uint8Array,
+  params: Pbkdf2Params,
+): Uint8Array {
+  return pbkdf2(sha256, passphrase, salt, {
+    c: params.iterations,
+    dkLen: params.dkLen ?? PBKDF2_DEFAULT_OUTPUT_LENGTH,
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,3 +82,19 @@ export interface EnvelopeV2 {
 }
 
 export type AnyEnvelope = EnvelopeV1 | EnvelopeV2;
+
+/**
+ * Branded type for the 32-byte master key that seeds `EnvelopeClient`
+ * (Phase IV) and keyring's tier system (`@de-otio/keyring`).
+ *
+ * The brand exists only in the type system — at runtime a `MasterKey` is a
+ * plain `ISecureBuffer`. The brand prevents a common key-confusion bug
+ * (design-review B8): passphrase-derived bytes leaving `deriveMasterKeyFromPassphrase`
+ * cannot be handed directly to an AEAD primitive as a CEK without an
+ * explicit unbranding cast, which becomes the audit-trail record of "I'm
+ * doing something the type system warned me about".
+ *
+ * Produced by `deriveMasterKeyFromPassphrase` or by explicit brand
+ * assertion via `asMasterKey(buf)` from `src/passphrase.ts`.
+ */
+export type MasterKey = ISecureBuffer & { readonly __brand: 'MasterKey' };

--- a/test/passphrase.test.ts
+++ b/test/passphrase.test.ts
@@ -1,0 +1,175 @@
+import { randomBytes } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PBKDF2_SHA256_MIN_ITERATIONS,
+  _resetPbkdf2WarnForTests,
+  asMasterKey,
+  deriveMasterKeyFromPassphrase,
+} from '../src/passphrase.js';
+import { SecureBuffer } from '../src/secure-buffer.js';
+
+describe('deriveMasterKeyFromPassphrase', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('Argon2id branch', () => {
+    it('returns a 32-byte MasterKey', async () => {
+      const salt = randomBytes(16);
+      const mk = await deriveMasterKeyFromPassphrase('hunter2', salt, { algorithm: 'argon2id' });
+      expect(mk.length).toBe(32);
+    });
+
+    it('is deterministic for matching passphrase + salt', async () => {
+      const salt = randomBytes(16);
+      const a = await deriveMasterKeyFromPassphrase('hunter2', salt, { algorithm: 'argon2id' });
+      const b = await deriveMasterKeyFromPassphrase('hunter2', salt, { algorithm: 'argon2id' });
+      expect(Buffer.from(a.buffer).equals(Buffer.from(b.buffer))).toBe(true);
+    });
+
+    it('differs when the salt changes', async () => {
+      const a = await deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+        algorithm: 'argon2id',
+      });
+      const b = await deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+        algorithm: 'argon2id',
+      });
+      expect(Buffer.from(a.buffer).equals(Buffer.from(b.buffer))).toBe(false);
+    });
+
+    it('does not emit the PBKDF2 compatibility warning', async () => {
+      await deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), { algorithm: 'argon2id' });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PBKDF2-SHA256 branch', () => {
+    it('returns a 32-byte MasterKey at the floor iteration count', async () => {
+      const salt = randomBytes(16);
+      const mk = await deriveMasterKeyFromPassphrase('hunter2', salt, {
+        algorithm: 'pbkdf2-sha256',
+        iterations: PBKDF2_SHA256_MIN_ITERATIONS,
+      });
+      expect(mk.length).toBe(32);
+    });
+
+    it('enforces the iteration floor (1,000,000) with a clear error', async () => {
+      await expect(
+        deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+          algorithm: 'pbkdf2-sha256',
+          iterations: 999_999,
+        }),
+      ).rejects.toThrow(/1000000|1_000_000/);
+    });
+
+    it('rejects non-integer iteration counts', async () => {
+      await expect(
+        deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+          algorithm: 'pbkdf2-sha256',
+          iterations: 1_000_000.5,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('emits exactly one compatibility warning per process (module flag)', async () => {
+      _resetPbkdf2WarnForTests();
+
+      await deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+        algorithm: 'pbkdf2-sha256',
+        iterations: PBKDF2_SHA256_MIN_ITERATIONS,
+      });
+      await deriveMasterKeyFromPassphrase('hunter2', randomBytes(16), {
+        algorithm: 'pbkdf2-sha256',
+        iterations: PBKDF2_SHA256_MIN_ITERATIONS,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/PBKDF2-SHA256|Argon2id/);
+    });
+
+    it('is deterministic for matching inputs', async () => {
+      const salt = randomBytes(16);
+      const a = await deriveMasterKeyFromPassphrase('hunter2', salt, {
+        algorithm: 'pbkdf2-sha256',
+        iterations: PBKDF2_SHA256_MIN_ITERATIONS,
+      });
+      const b = await deriveMasterKeyFromPassphrase('hunter2', salt, {
+        algorithm: 'pbkdf2-sha256',
+        iterations: PBKDF2_SHA256_MIN_ITERATIONS,
+      });
+      expect(Buffer.from(a.buffer).equals(Buffer.from(b.buffer))).toBe(true);
+    });
+  });
+
+  describe('AbortSignal', () => {
+    it('throws synchronously if the signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await expect(
+        deriveMasterKeyFromPassphrase(
+          'hunter2',
+          randomBytes(16),
+          { algorithm: 'argon2id' },
+          { signal: controller.signal },
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('throws post-derivation if the signal fires during the synchronous derive', async () => {
+      // Argon2id runs synchronously inside noble; we cannot actually interrupt
+      // it mid-iteration. This test documents the post-derivation abort path:
+      // the signal fires after we return from argon2id, before the MasterKey
+      // is returned to the caller.
+      const controller = new AbortController();
+      const promise = deriveMasterKeyFromPassphrase(
+        'hunter2',
+        randomBytes(16),
+        { algorithm: 'argon2id' },
+        { signal: controller.signal },
+      );
+      // Queue the abort for the next microtask — it may or may not land
+      // before the synchronous argon2id call depending on scheduling.
+      // In either case, one of the two checks (pre or post) must fire.
+      queueMicrotask(() => controller.abort());
+      try {
+        const mk = await promise;
+        // If scheduling raced, derive succeeded; sanity-check the output.
+        expect(mk.length).toBe(32);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+      }
+    });
+  });
+
+  describe('unknown algorithm', () => {
+    it('rejects at runtime', async () => {
+      await expect(
+        deriveMasterKeyFromPassphrase(
+          'hunter2',
+          randomBytes(16),
+          // biome-ignore lint/suspicious/noExplicitAny: exercising the unreachable branch
+          { algorithm: 'scrypt' as any, n: 1 } as any,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});
+
+describe('asMasterKey', () => {
+  it('brands a 32-byte SecureBuffer', () => {
+    const buf = SecureBuffer.from(randomBytes(32));
+    const mk = asMasterKey(buf);
+    // Brand is erased at runtime — this is purely a compile-time check.
+    expect(mk.length).toBe(32);
+  });
+
+  it('rejects buffers of the wrong length', () => {
+    const buf = SecureBuffer.from(randomBytes(16));
+    expect(() => asMasterKey(buf)).toThrow(/32 bytes/);
+  });
+});

--- a/test/passphrase.test.ts
+++ b/test/passphrase.test.ts
@@ -18,7 +18,10 @@ describe('deriveMasterKeyFromPassphrase', () => {
     warnSpy.mockRestore();
   });
 
-  describe('Argon2id branch', () => {
+  // Argon2id with t=3, m=64 MiB, p=1 is intentionally slow on pure-JS
+  // noble; two back-to-back derivations can exceed vitest's 5s default
+  // on slow CI runners. Raise the per-suite timeout.
+  describe('Argon2id branch', { timeout: 30_000 }, () => {
     it('returns a 32-byte MasterKey', async () => {
       const salt = randomBytes(16);
       const mk = await deriveMasterKeyFromPassphrase('hunter2', salt, { algorithm: 'argon2id' });
@@ -106,7 +109,7 @@ describe('deriveMasterKeyFromPassphrase', () => {
     });
   });
 
-  describe('AbortSignal', () => {
+  describe('AbortSignal', { timeout: 30_000 }, () => {
     it('throws synchronously if the signal is already aborted', async () => {
       const controller = new AbortController();
       controller.abort();

--- a/test/pbkdf2.test.ts
+++ b/test/pbkdf2.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { PBKDF2_DEFAULT_OUTPUT_LENGTH, pbkdf2Sha256 } from '../src/primitives/pbkdf2.js';
+import { RFC_7914_PBKDF2_SHA256 } from './vectors/kdf/pbkdf2-sha256-rfc-7914.js';
+
+const fromUtf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+const toHex = (b: Uint8Array): string => Buffer.from(b).toString('hex');
+
+describe('PBKDF2-SHA256 primitive', () => {
+  it('has a 32-byte default output length', () => {
+    expect(PBKDF2_DEFAULT_OUTPUT_LENGTH).toBe(32);
+  });
+
+  it('derives the default 32-byte key', () => {
+    const out = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 1 });
+    expect(out.length).toBe(32);
+  });
+
+  it('respects the requested dkLen', () => {
+    const out = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 1, dkLen: 64 });
+    expect(out.length).toBe(64);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const a = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 100 });
+    const b = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 100 });
+    expect(toHex(a)).toBe(toHex(b));
+  });
+
+  it('produces different output when the iteration count changes', () => {
+    const a = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 100 });
+    const b = pbkdf2Sha256(fromUtf8('passwd'), fromUtf8('salt'), { iterations: 101 });
+    expect(toHex(a)).not.toBe(toHex(b));
+  });
+
+  describe('RFC 7914 §11 Known-Answer Tests', () => {
+    for (const v of RFC_7914_PBKDF2_SHA256) {
+      it(v.name, () => {
+        const out = pbkdf2Sha256(fromUtf8(v.passphrase), fromUtf8(v.salt), {
+          iterations: v.iterations,
+          dkLen: v.dkLen,
+        });
+        expect(toHex(out)).toBe(v.dk);
+      });
+    }
+  });
+});

--- a/test/vectors/kdf/pbkdf2-sha256-rfc-7914.ts
+++ b/test/vectors/kdf/pbkdf2-sha256-rfc-7914.ts
@@ -1,0 +1,50 @@
+/**
+ * PBKDF2-SHA256 Known-Answer Tests.
+ *
+ * RFC 6070 defines PBKDF2-SHA1 vectors; RFC 7914 (scrypt) defines
+ * PBKDF2-SHA256 vectors in §11 as a building-block reference. These are
+ * the vectors most TypeScript PBKDF2 implementations reproduce; they are
+ * also mirrored in NIST CAVP for FIPS validation.
+ *
+ * A regression in `@noble/hashes/pbkdf2` or in our wrapper's iteration
+ * count / output length handling will fail one of these.
+ */
+
+export interface Pbkdf2Vector {
+  readonly name: string;
+  /** UTF-8 string passphrase (bytes encoded at test time). */
+  readonly passphrase: string;
+  /** UTF-8 string salt (bytes encoded at test time). */
+  readonly salt: string;
+  readonly iterations: number;
+  readonly dkLen: number;
+  /** Hex-encoded expected derived key. */
+  readonly dk: string;
+}
+
+export const RFC_7914_PBKDF2_SHA256: readonly Pbkdf2Vector[] = [
+  {
+    name: 'RFC 7914 §11 — "passwd" / "salt" / c=1',
+    passphrase: 'passwd',
+    salt: 'salt',
+    iterations: 1,
+    dkLen: 64,
+    dk:
+      '55ac046e56e3089fec1691c22544b605' +
+      'f94185216dde0465e68b9d57c20dacbc' +
+      '49ca9cccf179b645991664b39d77ef31' +
+      '7c71b845b1e30bd509112041d3a19783',
+  },
+  {
+    name: 'RFC 7914 §11 — "Password" / "NaCl" / c=80000',
+    passphrase: 'Password',
+    salt: 'NaCl',
+    iterations: 80000,
+    dkLen: 64,
+    dk:
+      '4ddcd8f60b98be21830cee5ef22701f9' +
+      '641a4418d04c0414aeff08876b34ab56' +
+      'a1d425a1225833549adb841b51c9b317' +
+      '6a272bdebba1d078478f62b397f33c8d',
+  },
+];


### PR DESCRIPTION
## Summary

Plan-02 Phase II. Adds WebCrypto-compatible PBKDF2-SHA256 alongside the existing Argon2id primitive, unifies both behind a single async `deriveMasterKeyFromPassphrase` that returns a branded `MasterKey`, and documents the Argon2id-preferred posture for EU/GDPR-adjacent consumers.

- **`MasterKey` brand** (design-review B8) — `ISecureBuffer & { readonly __brand: 'MasterKey' }`. Cannot be passed directly to an AEAD primitive as a CEK without an explicit unbranding cast.
- **`deriveMasterKeyFromPassphrase(passphrase, salt, params, options?)`** — async, AbortSignal-aware. Discriminated-union `PassphraseKdfParams`:
  - `{ algorithm: 'argon2id' }` — mandatory default. OWASP 2023 second-tier (`t=3, m=64 MiB, p=1, dkLen=32`).
  - `{ algorithm: 'pbkdf2-sha256', iterations: N }` — compatibility fallback. One-time `console.warn` when taken.
- **PBKDF2-SHA256 iteration floor: 1,000,000** (design-review S1, raised from OWASP 2023's 600,000 for 2026 hardware).
- **`pbkdf2Sha256`** primitive export under `./primitives` — thin `@noble/hashes/pbkdf2` wrapper. Pure JS, runs on every WebCrypto-compliant runtime.
- **`asMasterKey`** brand-assertion helper for advanced callers.

### Notes

- Argon2id was already `@noble/hashes`-backed (plan-01 Phase B). Plan-02 §5 "migrate from sodium-native" is a no-op here.
- Runtime deps unchanged.

## Tests (+21 → 255 total)

- **PBKDF2 primitive:** default output length, custom `dkLen`, determinism, iteration-count sensitivity, **RFC 7914 §11 PBKDF2-SHA256 KATs** (`c=1`, `c=80000`).
- **Passphrase module:** Argon2id round-trip/determinism/salt-sensitivity/no-warn, PBKDF2 round-trip at floor, floor enforcement (integer + minimum), warn-once behaviour, AbortSignal pre-abort + scheduling-race, unknown-algorithm runtime rejection.
- **`asMasterKey`:** length validation.

## Test plan

- [x] lint (biome + tsc --noEmit)
- [x] build (tsc ESM + CJS)
- [x] test on Node 22.22.2 (255 passed)
- [ ] CI matrix [ubuntu/macos/windows] × [Node 22, Node 24]

🤖 Generated with [Claude Code](https://claude.com/claude-code)