### PR TITLE
feat(phase-iv): EnvelopeClient algorithm selection + MessageCounter + AES-GCM hard cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `src/blob-id.ts` uses `getRandomBytes`.
 - No external API changes. The `node:crypto` imports are gone but consumers who relied only on the public exports see no difference.
 
+### Added — Phase IV (plan-02, EnvelopeClient algorithm selection + AES-GCM hard cap)
+
+- **`EnvelopeClient` algorithm selection.** Constructor gains an optional `algorithm?: Algorithm` option. Default remains `'XChaCha20-Poly1305'`; `'AES-256-GCM'` is available for interop with external systems. Decryption stays algorithm-agnostic — the envelope carries `enc.alg` and the client routes based on it, so a default-XChaCha client can still decrypt AES-GCM envelopes.
+- **`EnvelopeClient.forAesGcmInterop(options)`** named factory. The discoverable surface for AES-GCM (design-review blocker B9): the factory name signals the trade-off at the call-site. Mid-level consumers writing first-time code see `forAesGcmInterop` in IntelliSense and can investigate the per-key message cap before committing.
+- **`MessageCounter` interface** + **`InMemoryMessageCounter` default** in `src/message-counter.ts`. `async increment(keyFingerprint)` / `async current(keyFingerprint)`. The in-memory default resets on every process restart — suitable for CLI / single-process server use — and emits a one-time `console.warn` naming the limitation so multi-process / serverless consumers are prompted to supply a durable backend (SQLite, DynamoDB, Redis).
+- **Key fingerprint** via `keyFingerprint(commitKey)` — HMAC-SHA256 over the commit key with a fixed `"crypto-envelope/v1/keyfp"` label, truncated to 16 bytes. Safe to persist and log (HMAC one-wayness; 128 bits output is collision-resistant for indexing).
+- **`AES_GCM_HARD_CAP = 2^32`** constant + **`NonceBudgetExceeded`** error (design-review blocker B2). On every encrypt, the client increments the message counter; if the algorithm is AES-GCM and the new counter value exceeds the cap, encryption throws `NonceBudgetExceeded` with the fingerprint, counter value, and algorithm attached. Consumers are expected to rotate the master key and retry. XChaCha20-Poly1305 has no practical cap — its counter is incremented for rotation-policy observability (keyring consumes this) but no hard refusal applies.
+- Keyring integration hook: `client.keyFingerprint` (getter) and `client.currentCount()` (async) expose the fingerprint and current counter so `@de-otio/keyring`'s rotation policy can watch soft/hard thresholds.
+
+### Changed — Phase IV
+
+- **BREAKING (pre-1.0 alpha):** `EnvelopeClient.encrypt(...)` and `EnvelopeClient.decrypt(...)` are now **async**. The counter integration surfaces `Promise<number>` for durable backends; callers update one `await`. Chaoskb's consumer changes as part of plan-01 Phase F.
+- `src/envelope/v1.ts` `encryptV1` takes an optional `algorithm?: Algorithm` argument (defaulting to XChaCha20-Poly1305). `decryptV1` stays signature-stable and routes on `envelope.enc.alg`.
+- Envelope-client tests rewritten for the async signature (+13 new tests covering AES-GCM via direct option and factory, cross-algorithm decrypt, hard-cap enforcement with primed counters, fingerprint stability, counter sharing).
+
+### Notes — Phase IV
+
+- Durable `MessageCounter` implementations are the **consumer's** responsibility; the package ships only the in-memory default. Keyring's plan §7 and design-review open-question Q5 establish the contract.
+- Phase IV does not add Wycheproof-vector coverage for AES-GCM envelopes on top of what the primitive-level tests cover in Phase I — envelope-level integration relies on round-trip + tamper coverage. AES-GCM test-vector snapshots for `envelope-v1`/`v2` can land as a follow-up if a specific external system requires interop verification.
+
 
 ## [0.1.0-alpha.1] - 2026-04-18
 

--- a/src/envelope-client.ts
+++ b/src/envelope-client.ts
@@ -7,24 +7,84 @@ import {
   serializeV2,
   upgradeToV2,
 } from './envelope/index.js';
+import { InMemoryMessageCounter, type MessageCounter, keyFingerprint } from './message-counter.js';
 import { deriveCommitKey, deriveContentKey } from './primitives/hkdf.js';
 import { SecureBuffer } from './secure-buffer.js';
-import type { EnvelopeV1, ISecureBuffer } from './types.js';
+import type { Algorithm, EnvelopeV1, ISecureBuffer, MasterKey } from './types.js';
 
 export type WireFormat = 'v1' | 'v2';
+
+/**
+ * Per-key AES-256-GCM message budget. NIST SP 800-38D §8.3 caps safe
+ * use of 96-bit random nonces at 2³² encryptions — the birthday
+ * probability of nonce collision passes 2⁻³³ beyond this. The envelope
+ * client refuses further encryption once this threshold is reached
+ * (design-review blocker B2).
+ *
+ * XChaCha20-Poly1305 has a 192-bit nonce and no practical cap; the
+ * counter is still incremented for rotation-policy observability but
+ * no hard refusal applies.
+ */
+export const AES_GCM_HARD_CAP = 2 ** 32;
+
+/**
+ * Error thrown when the per-key AES-GCM message budget is exhausted.
+ * The wrapped `fingerprint` identifies which master key is out of
+ * budget; the consumer is expected to rotate and retry.
+ */
+export class NonceBudgetExceeded extends Error {
+  readonly code = 'NONCE_BUDGET_EXCEEDED';
+  readonly fingerprint: Uint8Array;
+  readonly counter: number;
+  readonly algorithm: Algorithm;
+
+  constructor(fingerprint: Uint8Array, counter: number, algorithm: Algorithm) {
+    super(
+      `per-key nonce budget exhausted for ${algorithm}: counter=${counter}, cap=${AES_GCM_HARD_CAP}. Rotate the master key and re-encrypt pending payloads.`,
+    );
+    this.name = 'NonceBudgetExceeded';
+    this.fingerprint = fingerprint;
+    this.counter = counter;
+    this.algorithm = algorithm;
+  }
+}
 
 export interface EnvelopeClientOptions {
   /**
    * 32-byte master key. Passed as a `Uint8Array` (copied into a
-   * SecureBuffer internally and zeroed after derivation) or as a
+   * `SecureBuffer` internally and zeroed after derivation), a
    * pre-existing `ISecureBuffer` (not disposed by the client — the
-   * caller owns its lifecycle).
+   * caller owns its lifecycle), or a branded `MasterKey` produced by
+   * `deriveMasterKeyFromPassphrase`.
    */
-  masterKey: Uint8Array | ISecureBuffer;
+  masterKey: MasterKey | Uint8Array | ISecureBuffer;
+
+  /**
+   * AEAD algorithm. Defaults to `'XChaCha20-Poly1305'` — the recommended
+   * choice for every new envelope. Select `'AES-256-GCM'` only for
+   * interop with external systems or FIPS-constrained environments; see
+   * {@link EnvelopeClient.forAesGcmInterop} for a safer call-site.
+   */
+  algorithm?: Algorithm;
+
   /** Wire format for `encrypt`. Defaults to `'v2'` (CBOR, ~33 % smaller). */
   format?: WireFormat;
+
   /** Opaque key identifier bound into the AAD. Defaults to `'default'`. */
   kid?: string;
+
+  /**
+   * Per-key message counter. Required for AES-256-GCM (the client
+   * enforces the 2³² hard cap against it). For XChaCha20-Poly1305 the
+   * counter is optional — the 192-bit nonce has no practical cap — but
+   * supplying it enables rotation-policy observability for keyring.
+   *
+   * Default: an in-process `InMemoryMessageCounter`. **Warning**: the
+   * in-memory implementation resets on every process restart, which is
+   * unsafe for multi-process or serverless topologies. Supply a durable
+   * implementation (SQLite, DynamoDB, Redis) in those settings.
+   */
+  messageCounter?: MessageCounter;
 }
 
 /**
@@ -32,15 +92,25 @@ export interface EnvelopeClientOptions {
  * keys in `SecureBuffer`s for the lifetime of the instance. Call
  * {@link EnvelopeClient.dispose} (or use `using`) when done.
  *
- *   using client = new EnvelopeClient({ masterKey });
- *   const wire = client.encrypt({ note: 'hello' });
- *   const back = client.decrypt(wire);
+ * ```ts
+ * using client = new EnvelopeClient({ masterKey });
+ * const wire = await client.encrypt({ note: 'hello' });
+ * const back = await client.decrypt(wire);
+ * ```
+ *
+ * Phase IV: `encrypt` / `decrypt` are now `async` because the message
+ * counter integration supplies a `Promise`-returning interface for
+ * durable backends. This is a breaking change within the pre-1.0 alpha
+ * line; chaoskb's consumer updates in plan-01 Phase F.
  */
 export class EnvelopeClient {
   private readonly cek: ISecureBuffer;
   private readonly commitKey: ISecureBuffer;
+  private readonly algorithm: Algorithm;
   private readonly format: WireFormat;
   private readonly kid: string;
+  private readonly messageCounter: MessageCounter;
+  private readonly fingerprint: Uint8Array;
   private _disposed = false;
 
   constructor(options: EnvelopeClientOptions) {
@@ -60,21 +130,64 @@ export class EnvelopeClient {
       commitBytes.fill(0);
     }
 
+    this.algorithm = options.algorithm ?? 'XChaCha20-Poly1305';
     this.format = options.format ?? 'v2';
     this.kid = options.kid ?? 'default';
+    this.messageCounter = options.messageCounter ?? new InMemoryMessageCounter();
+    this.fingerprint = keyFingerprint(new Uint8Array(this.commitKey.buffer));
+  }
+
+  /**
+   * Safer call-site for the AES-256-GCM path. The name is the
+   * discoverable warning — consumers opting in here are on notice that
+   * AES-GCM carries a per-key message cap that XChaCha20-Poly1305 does
+   * not. Design-review blocker B9.
+   *
+   * Equivalent to `new EnvelopeClient({ ...options, algorithm: 'AES-256-GCM' })`.
+   */
+  static forAesGcmInterop(options: Omit<EnvelopeClientOptions, 'algorithm'>): EnvelopeClient {
+    return new EnvelopeClient({ ...options, algorithm: 'AES-256-GCM' });
+  }
+
+  /** Expose the key fingerprint for consumers that wire rotation
+   *  policies (keyring's `@de-otio/keyring`). 16 bytes, stable across
+   *  process restarts, safe to persist and log. */
+  get keyFingerprint(): Uint8Array {
+    // Defensive copy — callers should not mutate the internal fingerprint.
+    return new Uint8Array(this.fingerprint);
+  }
+
+  /** Current message-counter value for this master. Useful for
+   *  rotation-policy triggers. */
+  async currentCount(): Promise<number> {
+    this.assertLive();
+    return this.messageCounter.current(this.fingerprint);
   }
 
   /**
    * Encrypt a canonicalisable JSON payload. Returns wire bytes in the
    * configured format (v2 CBOR by default).
+   *
+   * Increments the per-key message counter. Throws
+   * {@link NonceBudgetExceeded} if the counter crosses the AES-GCM hard
+   * cap (2³²). The hard cap applies only to AES-256-GCM; XChaCha20-Poly1305
+   * has no practical cap, and its counter is incremented for observability
+   * only.
    */
-  encrypt(payload: Record<string, unknown>): Uint8Array {
+  async encrypt(payload: Record<string, unknown>): Promise<Uint8Array> {
     this.assertLive();
+
+    const next = await this.messageCounter.increment(this.fingerprint);
+    if (this.algorithm === 'AES-256-GCM' && next > AES_GCM_HARD_CAP) {
+      throw new NonceBudgetExceeded(this.fingerprint, next, this.algorithm);
+    }
+
     const v1 = encryptV1({
       payload,
       cek: new Uint8Array(this.cek.buffer),
       commitKey: new Uint8Array(this.commitKey.buffer),
       kid: this.kid,
+      algorithm: this.algorithm,
     });
     return this.format === 'v2' ? serializeV2(upgradeToV2(v1)) : serializeV1(v1);
   }
@@ -82,9 +195,11 @@ export class EnvelopeClient {
   /**
    * Decrypt wire bytes. Auto-detects v1 JSON vs v2 CBOR on the magic
    * prefix. Returns the plaintext object. Throws on any cryptographic
-   * mismatch (wrong key, tampered envelope, failed commitment).
+   * mismatch (wrong key, tampered envelope, failed commitment). Works
+   * regardless of the algorithm used at encrypt time — the envelope
+   * carries `enc.alg`.
    */
-  decrypt(bytes: Uint8Array): Record<string, unknown> {
+  async decrypt(bytes: Uint8Array): Promise<Record<string, unknown>> {
     this.assertLive();
     const env = deserialize(bytes);
     const v1: EnvelopeV1 = env.v === 1 ? env : downgradeToV1(env);
@@ -112,7 +227,7 @@ export class EnvelopeClient {
   }
 }
 
-function getKeyBytes(key: Uint8Array | ISecureBuffer): Uint8Array {
+function getKeyBytes(key: MasterKey | Uint8Array | ISecureBuffer): Uint8Array {
   if (key instanceof Uint8Array) {
     return key;
   }

--- a/src/envelope/v1.ts
+++ b/src/envelope/v1.ts
@@ -6,7 +6,7 @@ import { TAG_LENGTH, aeadDecrypt, aeadEncrypt, nonceLengthFor } from '../primiti
 import { computeCommitment, verifyCommitment } from '../primitives/commitment.js';
 import type { Algorithm, EnvelopeV1 } from '../types.js';
 
-const ALG: Algorithm = 'XChaCha20-Poly1305';
+const DEFAULT_ALG: Algorithm = 'XChaCha20-Poly1305';
 const ENCODER = new TextEncoder();
 const DECODER = new TextDecoder();
 
@@ -19,6 +19,14 @@ export interface EncryptV1Args {
   commitKey: Uint8Array;
   /** Opaque key identifier; bound into AAD. */
   kid: string;
+  /**
+   * AEAD algorithm. Defaults to `'XChaCha20-Poly1305'`. AES-256-GCM is
+   * available for interop with external systems; the envelope client
+   * (Phase IV) enforces the 2³² per-key message cap on the GCM path.
+   * Callers using this function directly are responsible for honouring
+   * the cap themselves — see `src/message-counter.ts`.
+   */
+  algorithm?: Algorithm;
   /** ISO 8601 timestamp; defaults to `new Date().toISOString()`. */
   ts?: string;
   /** Blob identifier; defaults to {@link generateBlobId}. */
@@ -45,13 +53,14 @@ export interface EncryptV1Args {
  */
 export function encryptV1(args: EncryptV1Args): EnvelopeV1 {
   const { payload, cek, commitKey, kid } = args;
+  const alg: Algorithm = args.algorithm ?? DEFAULT_ALG;
   const id = args.id ?? generateBlobId();
   const ts = args.ts ?? new Date().toISOString();
 
   const plaintext = ENCODER.encode(canonicalJson(payload));
-  const aad = constructAAD(ALG, id, kid, 1);
+  const aad = constructAAD(alg, id, kid, 1);
 
-  const { nonce, ciphertext, tag } = aeadEncrypt(ALG, cek, plaintext, aad);
+  const { nonce, ciphertext, tag } = aeadEncrypt(alg, cek, plaintext, aad);
 
   const rawCt = new Uint8Array(nonce.length + ciphertext.length + tag.length);
   rawCt.set(nonce, 0);
@@ -61,7 +70,7 @@ export function encryptV1(args: EncryptV1Args): EnvelopeV1 {
   const commitment = computeCommitment(commitKey, id, rawCt);
 
   // Verify-after-encrypt — guards against a bug in the AEAD primitive.
-  const recovered = aeadDecrypt(ALG, cek, nonce, ciphertext, tag, aad);
+  const recovered = aeadDecrypt(alg, cek, nonce, ciphertext, tag, aad);
   if (!constantTimeEqual(recovered, plaintext)) {
     throw new Error('verify-after-encrypt failed: decrypted plaintext does not match input');
   }
@@ -71,7 +80,7 @@ export function encryptV1(args: EncryptV1Args): EnvelopeV1 {
     id,
     ts,
     enc: {
-      alg: ALG,
+      alg,
       kid,
       ct: Buffer.from(rawCt).toString('base64'),
       'ct.len': rawCt.length,
@@ -103,7 +112,7 @@ export function decryptV1(
   if (envelope.v !== 1) {
     throw new Error(`unsupported envelope version: ${envelope.v}`);
   }
-  if (envelope.enc.alg !== ALG) {
+  if (envelope.enc.alg !== 'XChaCha20-Poly1305' && envelope.enc.alg !== 'AES-256-GCM') {
     throw new Error(`unsupported algorithm: ${envelope.enc.alg}`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,17 @@ export { generateBlobId } from './blob-id.js';
 export { SecureBuffer } from './secure-buffer.js';
 export { constructAAD } from './aad.js';
 export {
+  AES_GCM_HARD_CAP,
   EnvelopeClient,
+  NonceBudgetExceeded,
   type EnvelopeClientOptions,
   type WireFormat,
 } from './envelope-client.js';
+export {
+  InMemoryMessageCounter,
+  keyFingerprint,
+  type MessageCounter,
+} from './message-counter.js';
 export {
   encryptV1,
   decryptV1,

--- a/src/message-counter.ts
+++ b/src/message-counter.ts
@@ -1,0 +1,98 @@
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+/**
+ * Per-key message counter. Exists to enforce AEAD per-key message budgets
+ * — critically, AES-256-GCM's birthday bound (NIST SP 800-38D §8.3 caps
+ * safe usage at 2³² encryptions per key with 96-bit random nonces).
+ *
+ * Keyring's rotation policy (`@de-otio/keyring` plan §7) watches the
+ * counter to emit soft/hard threshold events before the envelope
+ * client's own hard cap refuses further encryption.
+ *
+ * The interface is async to accommodate durable backends (SQLite,
+ * DynamoDB, Redis) needed when a master key is used from more than one
+ * process or host. The library ships an in-memory default suitable for
+ * CLI/worker scenarios where a single process owns the key.
+ */
+export interface MessageCounter {
+  /**
+   * Atomically increment the counter for the given key fingerprint and
+   * return the new value. Implementations must guarantee that two
+   * concurrent `increment` calls never return the same value.
+   */
+  increment(keyFingerprint: Uint8Array): Promise<number>;
+
+  /** Read the current counter without modifying it. */
+  current(keyFingerprint: Uint8Array): Promise<number>;
+}
+
+/**
+ * In-memory `MessageCounter` keyed by the hex of the fingerprint. Safe
+ * for single-process use (CLI, short-lived server, Web Worker). Not
+ * safe across process boundaries — every restart resets counters, so
+ * consumers on AWS Lambda / serverless should supply a durable
+ * implementation.
+ *
+ * Writes a one-time `console.warn` when first incremented so a caller
+ * who accidentally uses the default in a multi-process topology is at
+ * least made aware.
+ */
+export class InMemoryMessageCounter implements MessageCounter {
+  private readonly _map = new Map<string, number>();
+  private _warnEmitted = false;
+
+  async increment(keyFingerprint: Uint8Array): Promise<number> {
+    this.warnOnce();
+    const key = toHex(keyFingerprint);
+    const next = (this._map.get(key) ?? 0) + 1;
+    this._map.set(key, next);
+    return next;
+  }
+
+  async current(keyFingerprint: Uint8Array): Promise<number> {
+    return this._map.get(toHex(keyFingerprint)) ?? 0;
+  }
+
+  /** Internal: reset for tests. */
+  _reset(): void {
+    this._map.clear();
+    this._warnEmitted = false;
+  }
+
+  private warnOnce(): void {
+    if (this._warnEmitted) return;
+    this._warnEmitted = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[@de-otio/crypto-envelope] InMemoryMessageCounter used — counters reset on every process ' +
+        'restart, which can allow nonce-budget bypass under AES-GCM. Supply a durable MessageCounter ' +
+        '(SQLite / DynamoDB / Redis) in multi-process or serverless topologies.',
+    );
+  }
+}
+
+/**
+ * Compute a stable fingerprint for a master key. HMAC-SHA256 over the
+ * commitment key with a fixed label, truncated to 16 bytes.
+ *
+ * The fingerprint is safe to persist and log — it reveals nothing about
+ * the master (HMAC one-wayness) but is collision-resistant (128 bits of
+ * output is more than enough for keyed-store indexing). Using the commit
+ * key rather than the master or CEK keeps the fingerprint decoupled from
+ * the keys that actually encrypt/MAC.
+ */
+export function keyFingerprint(commitKey: Uint8Array): Uint8Array {
+  const full = hmac(sha256, commitKey, FINGERPRINT_LABEL);
+  return full.subarray(0, 16);
+}
+
+const FINGERPRINT_LABEL = new TextEncoder().encode('crypto-envelope/v1/keyfp');
+
+function toHex(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) {
+    s += (bytes[i] as number).toString(16).padStart(2, '0');
+  }
+  return s;
+}

--- a/test/envelope-client.test.ts
+++ b/test/envelope-client.test.ts
@@ -1,89 +1,251 @@
 import { randomBytes } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
-import { EnvelopeClient } from '../src/envelope-client.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AES_GCM_HARD_CAP, EnvelopeClient, NonceBudgetExceeded } from '../src/envelope-client.js';
+import { InMemoryMessageCounter, type MessageCounter } from '../src/message-counter.js';
 import { SecureBuffer } from '../src/secure-buffer.js';
 
 describe('EnvelopeClient', () => {
   const masterKey = new Uint8Array(32).fill(0x42);
 
-  describe('round-trip', () => {
-    it('encrypts and decrypts a payload (default v2)', () => {
+  // Suppress InMemoryMessageCounter's first-use warn — every instance
+  // prints it once, which clutters test output.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('round-trip (XChaCha20-Poly1305 default)', () => {
+    it('encrypts and decrypts a payload (default v2)', async () => {
       using client = new EnvelopeClient({ masterKey });
-      const wire = client.encrypt({ type: 'note', body: 'hello' });
+      const wire = await client.encrypt({ type: 'note', body: 'hello' });
       expect(wire[0]).toBe(0x43); // CBOR magic 'C'
-      expect(client.decrypt(wire)).toEqual({ type: 'note', body: 'hello' });
+      expect(await client.decrypt(wire)).toEqual({ type: 'note', body: 'hello' });
     });
 
-    it('encrypts and decrypts a payload (v1 opt-in)', () => {
+    it('encrypts and decrypts a payload (v1 opt-in)', async () => {
       using client = new EnvelopeClient({ masterKey, format: 'v1' });
-      const wire = client.encrypt({ type: 'note', body: 'hello' });
+      const wire = await client.encrypt({ type: 'note', body: 'hello' });
       expect(wire[0]).toBe(0x7b); // '{' — JSON opener
-      expect(client.decrypt(wire)).toEqual({ type: 'note', body: 'hello' });
+      expect(await client.decrypt(wire)).toEqual({ type: 'note', body: 'hello' });
     });
 
-    it('round-trips a large object', () => {
+    it('round-trips a large object', async () => {
       using client = new EnvelopeClient({ masterKey });
       const payload = {
         lines: Array.from({ length: 1000 }, (_, i) => `line ${i}`),
         metadata: { author: 'x', tags: ['a', 'b', 'c'] },
       };
-      expect(client.decrypt(client.encrypt(payload))).toEqual(payload);
+      expect(await client.decrypt(await client.encrypt(payload))).toEqual(payload);
     });
 
-    it('accepts a SecureBuffer masterKey without disposing it', () => {
+    it('accepts a SecureBuffer masterKey without disposing it', async () => {
       const sb = SecureBuffer.from(Uint8Array.from(masterKey));
       using client = new EnvelopeClient({ masterKey: sb });
-      const wire = client.encrypt({ x: 1 });
-      expect(client.decrypt(wire)).toEqual({ x: 1 });
+      const wire = await client.encrypt({ x: 1 });
+      expect(await client.decrypt(wire)).toEqual({ x: 1 });
       // Caller-supplied SecureBuffer stays live.
       expect(sb.isDisposed).toBe(false);
       sb.dispose();
     });
   });
 
-  describe('cross-format interop', () => {
-    it('decrypts a v1-serialised blob from a v2 client', () => {
-      using v1client = new EnvelopeClient({ masterKey, format: 'v1' });
-      using v2client = new EnvelopeClient({ masterKey, format: 'v2' });
-      const v1wire = v1client.encrypt({ x: 42 });
-      expect(v2client.decrypt(v1wire)).toEqual({ x: 42 });
+  describe('AES-256-GCM path', () => {
+    it('encrypts and decrypts via direct option', async () => {
+      using client = new EnvelopeClient({ masterKey, algorithm: 'AES-256-GCM' });
+      const wire = await client.encrypt({ x: 1 });
+      expect(await client.decrypt(wire)).toEqual({ x: 1 });
     });
 
-    it('decrypts a v2-serialised blob from a v1 client', () => {
+    it('encrypts and decrypts via `forAesGcmInterop` factory', async () => {
+      using client = EnvelopeClient.forAesGcmInterop({ masterKey });
+      const wire = await client.encrypt({ note: 'cross-system interop' });
+      expect(await client.decrypt(wire)).toEqual({ note: 'cross-system interop' });
+    });
+
+    it('round-trips AES-GCM envelopes through a default-XChaCha client', async () => {
+      // Decryption is alg-agnostic — it pulls alg from the envelope.
+      using aesClient = EnvelopeClient.forAesGcmInterop({ masterKey });
+      using xclient = new EnvelopeClient({ masterKey });
+      const wire = await aesClient.encrypt({ x: 1 });
+      expect(await xclient.decrypt(wire)).toEqual({ x: 1 });
+    });
+
+    it('round-trips in v1 wire format', async () => {
+      using client = EnvelopeClient.forAesGcmInterop({ masterKey, format: 'v1' });
+      const wire = await client.encrypt({ x: 1 });
+      expect(wire[0]).toBe(0x7b); // v1 JSON
+      const text = new TextDecoder().decode(wire);
+      expect(text).toContain('"alg":"AES-256-GCM"');
+      expect(await client.decrypt(wire)).toEqual({ x: 1 });
+    });
+
+    it('rejects a blob whose alg field was downgrade-tampered', async () => {
+      using client = EnvelopeClient.forAesGcmInterop({ masterKey, format: 'v1' });
+      const wire = await client.encrypt({ x: 1 });
+      const text = new TextDecoder().decode(wire);
+      const tampered = new TextEncoder().encode(
+        text.replace('"alg":"AES-256-GCM"', '"alg":"XChaCha20-Poly1305"'),
+      );
+      // AAD is bound with alg — swapping it breaks AEAD auth, then hits
+      // the nonce-width mismatch (12 vs 24). Either error is acceptable.
+      await expect(client.decrypt(tampered)).rejects.toThrow();
+    });
+  });
+
+  describe('cross-format interop', () => {
+    it('decrypts a v1-serialised blob from a v2 client', async () => {
       using v1client = new EnvelopeClient({ masterKey, format: 'v1' });
       using v2client = new EnvelopeClient({ masterKey, format: 'v2' });
-      const v2wire = v2client.encrypt({ x: 42 });
-      expect(v1client.decrypt(v2wire)).toEqual({ x: 42 });
+      const v1wire = await v1client.encrypt({ x: 42 });
+      expect(await v2client.decrypt(v1wire)).toEqual({ x: 42 });
+    });
+
+    it('decrypts a v2-serialised blob from a v1 client', async () => {
+      using v1client = new EnvelopeClient({ masterKey, format: 'v1' });
+      using v2client = new EnvelopeClient({ masterKey, format: 'v2' });
+      const v2wire = await v2client.encrypt({ x: 42 });
+      expect(await v1client.decrypt(v2wire)).toEqual({ x: 42 });
     });
   });
 
   describe('wrong key / tamper rejection', () => {
-    it('rejects a blob encrypted under a different master key', () => {
+    it('rejects a blob encrypted under a different master key', async () => {
       using a = new EnvelopeClient({ masterKey });
       using b = new EnvelopeClient({ masterKey: new Uint8Array(32).fill(0x99) });
-      const wire = a.encrypt({ x: 1 });
-      expect(() => b.decrypt(wire)).toThrow();
+      const wire = await a.encrypt({ x: 1 });
+      await expect(b.decrypt(wire)).rejects.toThrow();
     });
 
-    it("decrypts regardless of the decrypting client's configured kid", () => {
-      // kid is stored in the envelope itself; the decryptor pulls it from
-      // there to reconstruct AAD. The client's configured kid only
-      // controls what gets written on encrypt. A consumer that wants to
-      // enforce "only decrypt my own kids" must check it post-decrypt.
+    it("decrypts regardless of the decrypting client's configured kid", async () => {
       using a = new EnvelopeClient({ masterKey, kid: 'alice' });
       using b = new EnvelopeClient({ masterKey, kid: 'bob' });
-      const wire = a.encrypt({ x: 1 });
-      expect(b.decrypt(wire)).toEqual({ x: 1 });
+      const wire = await a.encrypt({ x: 1 });
+      expect(await b.decrypt(wire)).toEqual({ x: 1 });
     });
 
-    it('rejects a wire blob whose kid has been tampered with', () => {
+    it('rejects a wire blob whose kid has been tampered with', async () => {
       using client = new EnvelopeClient({ masterKey, format: 'v1' });
-      const wire = client.encrypt({ x: 1 });
+      const wire = await client.encrypt({ x: 1 });
       const text = new TextDecoder().decode(wire);
       const tampered = new TextEncoder().encode(
         text.replace('"kid":"default"', '"kid":"attacker"'),
       );
-      expect(() => client.decrypt(tampered)).toThrow();
+      await expect(client.decrypt(tampered)).rejects.toThrow();
+    });
+  });
+
+  describe('MessageCounter integration', () => {
+    it('increments the counter on every encrypt', async () => {
+      using client = new EnvelopeClient({ masterKey });
+      expect(await client.currentCount()).toBe(0);
+      await client.encrypt({ x: 1 });
+      expect(await client.currentCount()).toBe(1);
+      await client.encrypt({ x: 2 });
+      expect(await client.currentCount()).toBe(2);
+    });
+
+    it('exposes a stable keyFingerprint for the same master', () => {
+      using a = new EnvelopeClient({ masterKey });
+      using b = new EnvelopeClient({ masterKey });
+      expect(Buffer.from(a.keyFingerprint).equals(Buffer.from(b.keyFingerprint))).toBe(true);
+    });
+
+    it('produces a different keyFingerprint under a different master', () => {
+      using a = new EnvelopeClient({ masterKey });
+      using b = new EnvelopeClient({ masterKey: new Uint8Array(32).fill(0x99) });
+      expect(Buffer.from(a.keyFingerprint).equals(Buffer.from(b.keyFingerprint))).toBe(false);
+    });
+
+    it('shares counter state when the same MessageCounter is injected', async () => {
+      const counter = new InMemoryMessageCounter();
+      using a = new EnvelopeClient({ masterKey, messageCounter: counter });
+      using b = new EnvelopeClient({ masterKey, messageCounter: counter });
+      await a.encrypt({ x: 1 });
+      await b.encrypt({ x: 2 });
+      // Both clients hit the same fingerprint; the shared counter saw 2
+      // increments.
+      expect(await a.currentCount()).toBe(2);
+      expect(await b.currentCount()).toBe(2);
+    });
+  });
+
+  describe('AES-GCM hard cap (design-review B2)', () => {
+    it('throws NonceBudgetExceeded when the counter crosses 2^32', async () => {
+      // Inject a counter that starts at the cap so we don't need 4B iterations.
+      class PrimedCounter implements MessageCounter {
+        private n: number;
+        constructor(start: number) {
+          this.n = start;
+        }
+        async increment(): Promise<number> {
+          this.n += 1;
+          return this.n;
+        }
+        async current(): Promise<number> {
+          return this.n;
+        }
+      }
+      using client = EnvelopeClient.forAesGcmInterop({
+        masterKey,
+        messageCounter: new PrimedCounter(AES_GCM_HARD_CAP),
+      });
+
+      // One past cap → throw.
+      await expect(client.encrypt({ x: 1 })).rejects.toBeInstanceOf(NonceBudgetExceeded);
+    });
+
+    it('does NOT enforce a hard cap on XChaCha20-Poly1305', async () => {
+      class PrimedCounter implements MessageCounter {
+        private n: number;
+        constructor(start: number) {
+          this.n = start;
+        }
+        async increment(): Promise<number> {
+          this.n += 1;
+          return this.n;
+        }
+        async current(): Promise<number> {
+          return this.n;
+        }
+      }
+      using client = new EnvelopeClient({
+        masterKey,
+        messageCounter: new PrimedCounter(AES_GCM_HARD_CAP + 1),
+      });
+
+      // Past the AES-GCM cap, but XChaCha has no practical cap — does
+      // not throw.
+      const wire = await client.encrypt({ x: 1 });
+      expect(await client.decrypt(wire)).toEqual({ x: 1 });
+    });
+
+    it('NonceBudgetExceeded carries fingerprint, counter, and algorithm', async () => {
+      class PrimedCounter implements MessageCounter {
+        async increment(): Promise<number> {
+          return AES_GCM_HARD_CAP + 1;
+        }
+        async current(): Promise<number> {
+          return AES_GCM_HARD_CAP + 1;
+        }
+      }
+      using client = EnvelopeClient.forAesGcmInterop({
+        masterKey,
+        messageCounter: new PrimedCounter(),
+      });
+      try {
+        await client.encrypt({ x: 1 });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(NonceBudgetExceeded);
+        const err = e as NonceBudgetExceeded;
+        expect(err.code).toBe('NONCE_BUDGET_EXCEEDED');
+        expect(err.algorithm).toBe('AES-256-GCM');
+        expect(err.counter).toBeGreaterThan(AES_GCM_HARD_CAP);
+        expect(err.fingerprint.length).toBe(16);
+      }
     });
   });
 
@@ -101,17 +263,23 @@ describe('EnvelopeClient', () => {
       expect(() => client.dispose()).not.toThrow();
     });
 
-    it('rejects encrypt after dispose', () => {
+    it('rejects encrypt after dispose', async () => {
       const client = new EnvelopeClient({ masterKey });
       client.dispose();
-      expect(() => client.encrypt({ x: 1 })).toThrow('disposed');
+      await expect(client.encrypt({ x: 1 })).rejects.toThrow('disposed');
     });
 
-    it('rejects decrypt after dispose', () => {
+    it('rejects decrypt after dispose', async () => {
       const client = new EnvelopeClient({ masterKey });
-      const wire = client.encrypt({ x: 1 });
+      const wire = await client.encrypt({ x: 1 });
       client.dispose();
-      expect(() => client.decrypt(wire)).toThrow('disposed');
+      await expect(client.decrypt(wire)).rejects.toThrow('disposed');
+    });
+
+    it('rejects currentCount after dispose', async () => {
+      const client = new EnvelopeClient({ masterKey });
+      client.dispose();
+      await expect(client.currentCount()).rejects.toThrow('disposed');
     });
   });
 });


### PR DESCRIPTION
## Summary

Plan-02 Phase IV. Wires AES-256-GCM into `EnvelopeClient`, introduces the per-key `MessageCounter` interface, enforces the 2³² hard cap for AES-GCM (design-review blocker B2), and adds the `forAesGcmInterop` factory as the discoverable safe-by-construction call-site (blocker B9).

### EnvelopeClient changes

- **Algorithm selection** via optional `algorithm?: Algorithm` (default XChaCha20-Poly1305). Decryption stays algorithm-agnostic — reads `enc.alg`.
- **`EnvelopeClient.forAesGcmInterop(options)`** — named factory; the name is the signal at the call-site.
- **`encrypt` / `decrypt` now async.** Breaking change within pre-1.0 alpha; chaoskb consumer updates in plan-01 Phase F.
- Exposes `keyFingerprint` (16 bytes, HMAC-SHA256-derived, safe to log) and `currentCount()` for keyring's rotation-policy integration.

### MessageCounter

- `async increment(fp) / async current(fp)` interface — durable backends (SQLite, DynamoDB, Redis) plug in here.
- `InMemoryMessageCounter` default, one-time warn prompting serverless/multi-process consumers to supply durable backing.
- `keyFingerprint(commitKey)` helper.

### Hard cap (B2)

- `AES_GCM_HARD_CAP = 2^32` constant + `NonceBudgetExceeded` error carrying fingerprint + counter + algorithm.
- Enforced on every encrypt when `algorithm === 'AES-256-GCM'`. XChaCha20-Poly1305 is uncapped (192-bit nonce).

### Tests (+13 → 281 total)

- AES-GCM round-trip via direct option and factory.
- Cross-algorithm decrypt (AES-GCM envelope decrypted by default-XChaCha client).
- v1 wire format carries `"alg":"AES-256-GCM"`.
- alg-downgrade tamper rejection.
- Counter integration: increments, fingerprint stability, injected-counter sharing.
- Hard-cap enforcement via PrimedCounter fixture.
- XChaCha not capped (verifies the asymmetry).
- Error carries fingerprint / counter / algorithm.
- Async dispose paths.

## Test plan

- [x] lint (biome + tsc --noEmit)
- [x] build (tsc ESM + CJS)
- [x] test on Node 22.22.2 (281 passed)
- [ ] CI matrix [ubuntu/macos/windows] × [Node 22, Node 24]

🤖 Generated with [Claude Code](https://claude.com/claude-code)