### PR TITLE
chore: prep 0.2.0-alpha.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Added — Phase I (plan-02, AES-256-GCM primitive)
+## [0.2.0-alpha.1] - 2026-04-19
+
+Second pre-release. Implements plan-02 Phases I–IV — AES-256-GCM as a second AEAD algorithm, unified passphrase-KDF with `MasterKey` brand, strict-by-default browser `SecureBuffer`, and `EnvelopeClient` algorithm selection with the 2³² AES-GCM hard cap. The package now runs on any WebCrypto-compliant runtime (Node ≥22, modern browsers, Deno ≥2, Bun ≥1, Cloudflare Workers, Vercel Edge).
+
+Installs as `@de-otio/crypto-envelope@alpha`. The `@latest` tag remains deliberately unused until chaoskb and trellis each ship a production release on this line.
+
+**Breaking (pre-1.0 alpha line):** `EnvelopeClient.encrypt` / `decrypt` are now `async`; `aeadEncrypt` / `aeadDecrypt` primitives take an explicit `alg` parameter. No external API change for consumers that only use the envelope client's public surface via the v0.1 quick-use pattern, modulo the `async` update.
+
+### Added — Phase I (AES-256-GCM primitive)
 
 - **AES-256-GCM as a second AEAD algorithm** alongside XChaCha20-Poly1305. `Algorithm` union widens to `'XChaCha20-Poly1305' | 'AES-256-GCM'`. Implementation via `@noble/ciphers/aes`'s `gcm(key, nonce, aad)` — the same noble stack already shipping for XChaCha, no new runtime dependency.
 - `aeadEncrypt(alg, key, plaintext, aad)` / `aeadDecrypt(alg, key, nonce, ciphertext, tag, aad)` now take an explicit `alg` parameter (breaking change within the pre-1.0 alpha line — callers in this package already updated; chaoskb does not import the primitive directly).
@@ -22,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `NONCE_LENGTH` export remains as a `@deprecated` alias for `XCHACHA_NONCE_LENGTH` to keep any external callers compiling; removal scheduled for v0.3.
 - `Algorithm` type documents the 96-bit-vs-192-bit nonce trade-off, the per-key message bound for AES-GCM (2³² per NIST SP 800-38D §8.3, hard cap enforced in Phase IV per design-review blocker B2), and the commitment's key-committing (not context-committing) property.
 
-### Added — Phase II (plan-02, PBKDF2 + passphrase-KDF unification)
+### Added — Phase II (PBKDF2 + passphrase-KDF unification)
 
 - **`MasterKey` branded type** (`ISecureBuffer & { readonly __brand: 'MasterKey' }`) — the 32-byte key that seeds `EnvelopeClient` (Phase IV) and `@de-otio/keyring`'s tier system. The brand prevents key-confusion at compile time (design-review blocker B8): passphrase-derived bytes cannot be handed to an AEAD primitive as a CEK without an explicit unbranding cast.
 - **`deriveMasterKeyFromPassphrase(passphrase, salt, params, options?)`** in `src/passphrase.ts` — unified, async, branded-return passphrase KDF with `AbortSignal` support. Discriminated-union `PassphraseKdfParams`:
@@ -40,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Argon2id migration (design-review B3 / plan §5 / §3.2) is a no-op.** chaoskb's `sodium-native`-backed Argon2 was extracted to `@noble/hashes/argon2` back in Phase B of plan-01 (see v0.1.0-alpha.1 entry below), so Phase II has no algorithm-implementation change on the Argon2 side — only the unified caller surface is new.
 - Runtime deps unchanged: `@noble/hashes` was already at the required version; `sodium-native` stays for `SecureBuffer`'s mlock/zero (Node-only, unchanged).
 
-### Added — Phase III (plan-02, SecureBuffer browser variant + runtime portability)
+### Added — Phase III (SecureBuffer browser variant + runtime portability)
 
 - **`SecureBufferBrowser`** in `src/secure-buffer.browser.ts` — strict-by-default `ISecureBuffer` implementation for runtimes without `mlock`. Constructor and factory methods require an explicit `{ insecureMemory: true }` acknowledgement; omitting the flag **throws** rather than silently degrading (design-review Q1 / chaoskb browser plugin threat model). Fresh `ArrayBuffer` per allocation — no pool aliasing. `fill(0)` on dispose (best-effort; documented limitation — V8 GC may relocate before the zero).
 - **`InsecureMemoryAck` type** exported from `src/secure-buffer.ts`. Node's `SecureBuffer` accepts it as an optional no-op second arg to `from` / `alloc` so portable code can pass the flag everywhere; runtime asymmetry is that Node ignores it and browser enforces it.
@@ -58,7 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `src/blob-id.ts` uses `getRandomBytes`.
 - No external API changes. The `node:crypto` imports are gone but consumers who relied only on the public exports see no difference.
 
-### Added — Phase IV (plan-02, EnvelopeClient algorithm selection + AES-GCM hard cap)
+### Added — Phase IV (EnvelopeClient algorithm selection + AES-GCM hard cap)
 
 - **`EnvelopeClient` algorithm selection.** Constructor gains an optional `algorithm?: Algorithm` option. Default remains `'XChaCha20-Poly1305'`; `'AES-256-GCM'` is available for interop with external systems. Decryption stays algorithm-agnostic — the envelope carries `enc.alg` and the client routes based on it, so a default-XChaCha client can still decrypt AES-GCM envelopes.
 - **`EnvelopeClient.forAesGcmInterop(options)`** named factory. The discoverable surface for AES-GCM (design-review blocker B9): the factory name signals the trade-off at the call-site. Mid-level consumers writing first-time code see `forAesGcmInterop` in IntelliSense and can investigate the per-key message cap before committing.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Opinionated authenticated-encryption envelopes for TypeScript.** Makes best-practice cryptography accessible to application developers while preventing common implementation mistakes (nonce reuse, skipped AAD, weak KDFs, silent decryption failure, …).
 
-> **Status: pre-release (`0.1.0-alpha`).** The envelope layer is complete and internally consumed by [chaoskb](https://github.com/de-otio/chaoskb) and [trellis](https://github.com/de-otio/trellis). The `@latest` tag is reserved until both of those ship production releases on this package; install the alpha explicitly. The wire format is considered mutable between `0.x` minors until then.
+> **Status: pre-release (`0.2.0-alpha`).** AES-256-GCM as a second AEAD, unified passphrase-KDF with branded `MasterKey`, strict-by-default browser `SecureBuffer`, and per-key `MessageCounter` with a 2³² AES-GCM hard cap landed in this line. Internally consumed by [chaoskb](https://github.com/de-otio/chaoskb) and [trellis](https://github.com/de-otio/trellis). The `@latest` tag is reserved until both of those ship production releases; install the alpha explicitly. The wire format is considered mutable between `0.x` minors until then.
 
 ## What it is
 
@@ -24,20 +24,50 @@ The package is small and opinionated. It does one thing: encrypt and decrypt sel
 npm install @de-otio/crypto-envelope@alpha
 ```
 
-Node 22+ required. The package pulls in `sodium-native` (for `mlock`'d secure memory), which builds prebuilt binaries on install — no extra toolchain or `playwright`-style post-install step.
+**Supported runtimes:** Node ≥22, modern browsers (MV3 extensions and pages), Deno ≥2, Bun ≥1, Cloudflare Workers, Vercel Edge. On Node, the package uses `sodium-native` for `mlock`'d secure memory (prebuilt binaries; no extra toolchain). On browsers and other WebCrypto-only runtimes, a strict-by-default `SecureBufferBrowser` is substituted via the `"browser"` field; constructing one requires an explicit `{ insecureMemory: true }` acknowledgement because browser runtimes cannot `mlock`.
 
 ## Quick start
 
 ```typescript
 import { EnvelopeClient } from '@de-otio/crypto-envelope';
-import { randomBytes } from 'node:crypto';
 
-using client = new EnvelopeClient({ masterKey: randomBytes(32) });
+using client = new EnvelopeClient({ masterKey: crypto.getRandomValues(new Uint8Array(32)) });
 
-const wire = client.encrypt({ type: 'note', body: 'hello' });
-const back = client.decrypt(wire);
+const wire = await client.encrypt({ type: 'note', body: 'hello' });
+const back = await client.decrypt(wire);
 // → { type: 'note', body: 'hello' }
 ```
+
+`encrypt` / `decrypt` are async (the per-key `MessageCounter` uses a `Promise`-returning interface so durable backends — SQLite, DynamoDB, Redis — can plug in). `wire` is a `Uint8Array` in the compact v2 (CBOR) wire format by default; opt into v1 JSON with `{ format: 'v1' }`, both round-trip losslessly.
+
+### Passphrase unlock
+
+```typescript
+import {
+  EnvelopeClient,
+  deriveMasterKeyFromPassphrase,
+} from '@de-otio/crypto-envelope';
+
+const masterKey = await deriveMasterKeyFromPassphrase(
+  'correct horse battery staple',
+  salt, // 16+ random bytes, persisted alongside the ciphertext
+  { algorithm: 'argon2id' },
+);
+
+using client = new EnvelopeClient({ masterKey });
+```
+
+Argon2id is the mandated default (OWASP 2023 second-tier: t=3, m=64 MiB, p=1). PBKDF2-SHA256 is available as a compatibility-only fallback for WebCrypto-constrained runtimes; the iteration floor is 1,000,000 and taking this branch emits a one-time warn.
+
+### AES-256-GCM for interop
+
+```typescript
+import { EnvelopeClient } from '@de-otio/crypto-envelope';
+
+using client = EnvelopeClient.forAesGcmInterop({ masterKey });
+```
+
+XChaCha20-Poly1305 is the default for every new envelope. Prefer `forAesGcmInterop` only when decrypting or interoperating with systems that require AES-GCM (or FIPS-constrained environments). AES-GCM carries a 2³² per-key message cap — the client refuses further encryption past this via `NonceBudgetExceeded`.
 
 `wire` is a `Uint8Array` in the compact v2 (CBOR) wire format by default. Opt into v1 JSON with `{ format: 'v1' }`; both round-trip losslessly via `upgradeToV2` / `downgradeToV1`, and `decrypt()` auto-detects.
 
@@ -61,17 +91,19 @@ const recovered = decryptV1(envelope, cek, commitKey);
 
 Design justification for each feature traces back to a specific class of application-level crypto mistake:
 
-- **Nonce reuse** → 192-bit random nonces via XChaCha20-Poly1305; nonces are never user-supplied in the public API.
+- **Nonce reuse** → 192-bit random nonces via XChaCha20-Poly1305 (default). AES-256-GCM's 96-bit nonce is available for interop with a hard 2³² per-key message cap enforced at `EnvelopeClient` — cross-process counter state is pluggable via `MessageCounter`. Nonces are never user-supplied in the public API.
 - **Skipped AAD / version downgrade** → AAD is mandatory and binds version + algorithm + blob ID + key identifier.
-- **Multi-key / partitioning-oracle attacks** → dedicated commitment key via HKDF with its own domain-separation string; commitment HMAC binds to blob ID; verified **before** AEAD.
+- **Algorithm substitution** → `alg` bound into AAD; nonce-width check rejects cross-algorithm ciphertext at the primitive.
+- **Multi-key / partitioning-oracle attacks** → dedicated commitment key via HKDF with its own domain-separation string; commitment HMAC binds to blob ID; verified **before** AEAD (key-committing, not context-committing — see SECURITY.md).
 - **Silent serialization drift** → RFC 8785 canonical JSON for plaintext + verify-after-encrypt (every output round-trips through decrypt before release).
-- **Weak KDF parameters** → Argon2id at OWASP-2023 second-tier (t=3, m=64 MiB, p=1, dkLen=32). No weaker option exposed.
-- **Timing attacks** → constant-time comparisons throughout (`crypto.timingSafeEqual` in Node).
-- **Keys in swap / crash dumps** → `SecureBuffer` via `sodium_malloc` / `sodium_memzero`.
-- **`Math.random` for keys** → CSPRNG only; no user-callable RNG for security-sensitive values.
+- **Weak KDF parameters** → Argon2id at OWASP-2023 second-tier (t=3, m=64 MiB, p=1, dkLen=32) as the mandated default. PBKDF2-SHA256 available for WebCrypto-only runtimes with a 1,000,000 iteration floor and a first-use warning.
+- **Key confusion** → `MasterKey` branded type prevents passphrase-derived bytes from being handed to an AEAD primitive as a CEK without an explicit unbranding cast.
+- **Timing attacks** → constant-time comparisons throughout (pure-JS XOR-accumulate; portable across runtimes).
+- **Keys in swap / crash dumps** → `SecureBuffer` via `sodium_malloc` / `sodium_memzero` on Node. Browsers and other mlock-less runtimes get a **strict-by-default** `SecureBufferBrowser` requiring `{ insecureMemory: true }` at construction — no silent degradation.
+- **`Math.random` for keys** → `globalThis.crypto.getRandomValues` only; no user-callable RNG for security-sensitive values. Throws on missing WebCrypto rather than falling back.
 - **Silent decryption failure** → commitment verified before AEAD; decrypt either returns plaintext or throws.
 
-Published test vectors cover RFC 8785 canonicalisation, RFC 5869 Appendix A.1 HKDF-SHA256, RFC 4231 §4.3 HMAC-SHA256, `draft-irtf-cfrg-xchacha` §A.3.1 XChaCha20-Poly1305 KAT (via decrypt path), and an Argon2id cross-implementation KAT against libsodium's `crypto_pwhash`.
+Published test vectors cover RFC 8785 canonicalisation, RFC 5869 Appendix A.1 HKDF-SHA256, RFC 4231 §4.3 HMAC-SHA256, `draft-irtf-cfrg-xchacha` §A.3.1 XChaCha20-Poly1305 KAT, an Argon2id cross-implementation KAT against libsodium's `crypto_pwhash`, RFC 7914 §11 PBKDF2-SHA256 vectors, NIST SP 800-38D / McGrew-Viega AES-256-GCM test cases 13–16, and 66 Wycheproof adversarial AES-256-GCM vectors (keySize=256 / ivSize=96 / tagSize=128).
 
 ## Maintenance posture
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-otio/crypto-envelope",
-  "version": "0.1.0-alpha.1",
-  "description": "Opinionated authenticated-encryption envelopes for TypeScript. XChaCha20-Poly1305 AEAD + AAD binding + HMAC-SHA256 key commitment + RFC 8785 canonical JSON + Argon2id + SecureBuffer. Safe defaults that can't be turned off.",
+  "version": "0.2.0-alpha.1",
+  "description": "Opinionated authenticated-encryption envelopes for TypeScript. XChaCha20-Poly1305 + AES-256-GCM AEAD + AAD binding + HMAC-SHA256 key commitment + RFC 8785 canonical JSON + Argon2id/PBKDF2 passphrase-KDF + SecureBuffer. Safe defaults that can't be turned off. Runs on Node, browsers (MV3), Deno, Bun, Cloudflare Workers.",
   "license": "MIT",
   "author": {
     "name": "De Otio",


### PR DESCRIPTION
## Summary

Plan-02 Phase V — cut the **0.2.0-alpha.1** release after Phases I–IV merged to main.

- `package.json`: version 0.1.0-alpha.1 → 0.2.0-alpha.1; description widened.
- `CHANGELOG.md`: `[Unreleased]` consolidated under `[0.2.0-alpha.1] - 2026-04-19` with a top-level summary; heading style normalised.
- `README.md`: status banner to `0.2.0-alpha`, supported-runtimes matrix (Node ≥22, browsers, Deno ≥2, Bun ≥1, CF Workers, Vercel Edge), Quick-start updated for async `encrypt/decrypt` + `crypto.getRandomValues`, new examples for passphrase unlock (Argon2id) and AES-GCM via `forAesGcmInterop`, expanded "protects against" list, extended test-vector list.

## Test plan

- [x] lint (biome + tsc --noEmit)
- [x] build (tsc ESM + CJS)
- [x] `test:all` on Node 22.22.2 (287 passed — includes the slow Argon2id cross-implementation KAT)
- [ ] CI matrix on PR
- [ ] Merge → tag `v0.2.0-alpha.1` → publish workflow picks `alpha` dist-tag via OIDC Trusted Publishing

After merge + tag push, npm will see `@de-otio/crypto-envelope@0.2.0-alpha.1` on the `@alpha` dist-tag. `@latest` stays unchanged (reserved for post-consumer-production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)